### PR TITLE
Update issn.js

### DIFF
--- a/issn.js
+++ b/issn.js
@@ -43,7 +43,7 @@
                 return sum + (value * (index + 2));
               }, 0) % 11;
 
-      var checkDigit = 11 - result;
+      var checkDigit = (result === 0) ? 0 : 11 - result;
       if (checkDigit === 10) {
         checkDigit = 'X';
       }


### PR DESCRIPTION
Fixed bug in calculateCheckDigitFor function when the result variable will return 0. Gives false-negatives for some ISSNs (i.e. "0040-4020").
