### PR TITLE
Add options object to allow finer-grained validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+###
+
+- Added `options` argument to allow stricter validation; see README.
+
 ### Changed
 
 - Updated (most) dependencies to their latest versions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [International Standard Serial Number (ISSN)](http://www.issn.org/understanding-the-issn/what-is-an-issn/) Validation
 
-[![NPM](https://nodei.co/npm/issn.png?compact=true)](https://nodei.co/npm/issn/)
+## Install
 
 ```bash
 npm install issn
@@ -10,14 +10,21 @@ npm install issn
 const issn = require("issn");
 ```
 
-Validate ISSNs.
+## Validate ISSNs
 
 ```js
 issn("0355-4325"); // true
 issn("0xDEDBEEF"); // false
 ```
 
-Format ISSNs.
+You can force strict validation: when `strict` is `true` the hyphen is required.
+
+```js
+issn("03554325"); // true; hyphen is optional by default
+issn("03554325", { strict: true }); // false
+```
+
+# Format ISSNs
 
 ```js
 issn.format("0355-4325"); // '0355-4325'
@@ -26,7 +33,7 @@ issn.format("0001253x"); // '0001-253X'
 issn.format("0xDEDBEEF"); // undefined
 ```
 
-Calculate the check-digit.
+## Calculate the check-digit
 
 ```js
 issn.calculateCheckDigit("0355432"); // '5'
@@ -39,7 +46,13 @@ issn.calculateCheckDigit("0001253"); // 'X'
 $ issn <ISSN>
 ```
 
-Here's another example piping some canned output through [jq](https://stedolan.github.io/jq/).
+You can turn on _strict_ validation using the `-strict` flag:
+
+```bash
+$ issn -strict <ISSN>
+```
+
+Here's an example piping some JSON through [jq](https://stedolan.github.io/jq/).
 
 ```bash
 $ echo {\"prism:pissn\": \"0000-0019\"} | jq -r '.["prism:pissn"]' | issn

--- a/cli.js
+++ b/cli.js
@@ -2,47 +2,38 @@
 'use strict';
 
 var stdin = require('get-stdin'),
-    argv = require('minimist')(process.argv.slice(2)),
-    pkg = require('./package.json'),
+    yargs = require('yargs'),
+    { hideBin } = require('yargs/helpers'),
     issn = require('./'),
+    args = yargs(hideBin(process.argv))
+      .scriptName("issn")
+      .option('strict', {
+        alias: 's',
+        type: 'boolean',
+        description: 'Enable strict validation'
+      })
+      .usage('Validate an ISSN')
+      .example([
+        ['$0 0000-0019'],
+        ['$0 --strict 0000-0019', 'Strict validation: the hyphen in the ISSN is required']
+      ]),
+    argv = args.parse(),
     input = argv._;
 
-function help() {
-  console.log([
-    '',
-    '  ' + pkg.description,
-    '',
-    '  Usage',
-    '    issn <ISSN>',
-    '',
-    '  Example',
-    '    issn 0000-0019',
-    '    true'
-  ].join('\n'));
-}
-
 function init(data) {
-  console.log(issn(data));
-}
-
-if (argv.version) {
-  console.log(pkg.version);
-  return;
-}
-
-if (argv.help) {
-  help();
-  return;
+  var isValid = issn(data, {
+    strict: argv.strict === true
+  });
+  console.log(isValid);
 }
 
 if (process.stdin.isTTY) {
   if (input.length === 0) {
-    help();
-    return;
+    args.help();
+    process.exit(1);
+  } else {
+    init(input[0]);
   }
-
-  init(input[0]);
-
 } else {
   stdin(function (data) {
     init(data.replace(/(\n|\r)+$/, ''));

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,13 @@
 export = issn;
 
-declare function issn(issn: any): boolean;
+declare type ValidationOptions = {
+  strict: boolean;
+};
+
+declare function issn(issn: any, options?: ValidationOptions): boolean;
 
 declare namespace issn {
+  function format(issn: any): string;
 
-    function format(issn: any): string;
-
-    function calculateCheckDigit(digits: string): string;
+  function calculateCheckDigit(digits: string): string;
 }

--- a/issn.js
+++ b/issn.js
@@ -3,12 +3,17 @@
   var issn = function () {
     'use strict';
 
-    var issnPattern = '^(\\d{4})-?(\\d{3})([\\dX])$';
-    var isIssnStrict = new RegExp(issnPattern);
-    var isIssnLax = new RegExp(issnPattern, 'i');
+    var isIssnLax = new RegExp('^(\\d{4})-?(\\d{3})([\\dX])$', 'i');
 
-    function validate(issn) {
-      var matches = text(issn).match(isIssnStrict);
+    function validate(issn, options) {
+      var opts = options ? options : { strict: false };
+
+      var issnPattern = opts.strict === true
+        ? '^(\\d{4})-(\\d{3})([\\dX])$'   // hyphen is required
+        : '^(\\d{4})-?(\\d{3})([\\dX])$'; // hyphen is optional
+      var isIssn = new RegExp(issnPattern);
+
+      var matches = text(issn).match(isIssn);
       if (!matches) {
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issn",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "ISSN Validation",
   "main": "issn.js",
   "bin": "cli.js",
@@ -31,13 +31,13 @@
     "url": "https://github.com/richdouglasevans/issn/issues"
   },
   "devDependencies": {
-    "expect": "^29.0.1",
-    "jasmine": "^4.3.0",
+    "expect": "^29.0.3",
+    "jasmine": "^4.4.0",
     "jasmine-node": "3.0.0",
     "lodash": "^4.17.21"
   },
   "dependencies": {
     "get-stdin": "7.0.0",
-    "minimist": "^1.2.6"
+    "yargs": "^17.5.1"
   }
 }

--- a/test/issn-validate-spec.js
+++ b/test/issn-validate-spec.js
@@ -16,8 +16,28 @@ describe('ISSN .validate', function () {
       expect(issn('0001-253X')).toBeTruthy();
     });
 
-    it('no -.', function () {
+    it('no hyphen (defaults to strict=false)', function () {
       expect(issn('03554325')).toBeTruthy();
+    });
+
+    it('no hyphen and [null] strict option. (defaults to strict=false)', function () {
+      expect(issn('03554325', { strict: null })).toBeTruthy();
+    });
+
+    it('no hyphen and [undefined] strict option. (defaults to strict=false)', function () {
+      expect(issn('03554325', { strict: undefined })).toBeTruthy();
+    });
+
+    it('no hyphen and [0] strict option. (defaults to strict=false)', function () {
+      expect(issn('03554325', { strict: 0 })).toBeTruthy();
+    });
+
+    it('no hyphen and [1] strict option. (defaults to strict=false)', function () {
+      expect(issn('03554325', { strict: 1 })).toBeTruthy();
+    });
+
+    it('no hyphen and [{}] strict option. (defaults to strict=false)', function () {
+      expect(issn('03554325', { strict: {} })).toBeTruthy();
     });
   });
 
@@ -45,6 +65,10 @@ describe('ISSN .validate', function () {
 
     it('not a string.', function () {
       expect(issn({song: '212'})).toBeFalsy();
+    });
+
+    it('no hyphen when the strict option is true.', function () {
+      expect(issn('03554325', { strict: true })).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Closes #47 

```js
// valid; hyphen is optional by default
issn("03554325")
```

```js
// invalid; hyphen is mandatory when strict is enabled
issn("03554325", { strict: true });
```